### PR TITLE
Fix TeX file export extension

### DIFF
--- a/src/main/java/net/sf/latexdraw/command/ExportFormat.java
+++ b/src/main/java/net/sf/latexdraw/command/ExportFormat.java
@@ -24,7 +24,7 @@ public enum ExportFormat {
 	TEX {
 		@Override
 		public @NotNull FileChooser.ExtensionFilter getFilter() {
-			return new FileChooser.ExtensionFilter("TeX", "*." + getFileExtension()); //NON-NLS
+			return new FileChooser.ExtensionFilter("TeX", "*" + getFileExtension()); //NON-NLS
 		}
 
 		@Override


### PR DESCRIPTION
PSTricks exports were saved as "*..tex" extensions. Changed to only ".tex".